### PR TITLE
241014 백준 11425 java

### DIFF
--- a/강재연/BOJ/B11425.java
+++ b/강재연/BOJ/B11425.java
@@ -1,0 +1,32 @@
+//문제 링크: https://www.acmicpc.net/problem/14425
+//시간: 284 ms
+//메모리: 38996 KB
+
+import java.io.*;
+import java.util.*;
+
+public class boj14425 {
+
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		int N = Integer.parseInt(st.nextToken());
+		int M = Integer.parseInt(st.nextToken());
+		Map<String, Integer> map = new HashMap<>();
+		
+		for(int i=0; i<N; i++) {
+			// N개만큼 map에 추가
+			map.put(br.readLine(), 0);
+		}
+		
+		int cnt = 0 ;
+		for(int j=0; j<M; j++) {
+			// M개만큼 반복하면서 해당 단어가 map의 키로 존재하면 cnt++ 
+			if( map.get(br.readLine()) != null ) cnt ++;
+		}
+		
+		System.out.println(cnt);
+	}
+
+}


### PR DESCRIPTION
같은 문제를 `Map`이랑 `ArrayList` 그리고 `배열`로 각각 풀어봤습니당
- `Map`은 키를 통해 검색하기 때문에 `O(1)`의 시간복잡도
- `ArrayList`는 리스트를 처음부터 끝까지 순차적으로 탐색해야 하기 때문에 `O(n)`
- 배열은 중첩반복문을 사용해야 하고 최악의 경우 `O(n*m)`

그래서 최종적으로 해시맵을 쓰는걸 올립니다!! 

별개로 왠지 `map.getOrDefault()`를 써야겠다고 정신이 팔려서 헛스윙을 되게 오래했네요... 