### PR TITLE
241018 프로그래머스 12945 javascript

### DIFF
--- a/이도이/programmers/12945 javascript
+++ b/이도이/programmers/12945 javascript
@@ -1,0 +1,13 @@
+문제 링크: https://school.programmers.co.kr/learn/courses/30/lessons/12945
+시간: 7.10ms
+메모리: 38.9MB
+
+function solution(n) {
+    let f = [0, 1]
+    
+    for(let i=2; i<=n; i++){  
+         f[i] = (f[i-2]+f[i-1])%1234567    
+    }
+   
+    return f[n]
+}


### PR DESCRIPTION
n의 범위가 커서 return 해줄 때 f[n]%1234567 이런식으로 해줬더니 오버플로우가 발생했습니다!!
그래서 애초에 배열에 넣어줄 때 나머지 값으로 넣는 방식으로 수정했어요!! 

47번째 피보나치 수는 2,971,215,073이고, 이 수는 32비트 정수(ex. int) 범위를 넘어 오버플로우가 발생합니다.
100,000번째 피보나치 수는 자릿수가 20,000을 넘어가며, 이는 64비트 정수(ex. long) 범위를 넘어 오버플로우가 발생합니다.
요렇다고 하네요!!!