### PR TITLE
250205 백준 1976 java

### DIFF
--- a/공소연/BOJ/B1976.java
+++ b/공소연/BOJ/B1976.java
@@ -1,0 +1,63 @@
+// 링크: https://www.acmicpc.net/problem/1976
+// 시간: 160ms
+// 메모리: 17420KB
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+    static int[] parents;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int n = Integer.parseInt(br.readLine()); // 도시의 수
+        int m = Integer.parseInt(br.readLine()); // 여행 계획에 속한 도시들의 수
+
+        parents = new int[n];
+        for (int i = 0; i < n; i++) {
+            parents[i] = i;
+        }
+
+        // 연결 정보
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < n; j++) {
+                if (Integer.parseInt(st.nextToken()) == 1) {
+                    union(i, j);
+                }
+            }
+        }
+        
+        // 여행 계획
+        st = new StringTokenizer(br.readLine());
+        String answer = "YES";
+        Integer parent = null;
+        for (int i = 0; i < m; i++) {
+            int node = Integer.parseInt(st.nextToken()) - 1;
+            int parent_node = find(node);
+            if (parent != null && parent != parent_node) {
+                answer = "NO";
+                break;
+            }
+            parent = parent_node;
+        }
+        
+        System.out.println(answer);
+    }
+
+    static void union(int a, int b) {
+        int parent_a = find(a);
+        int parent_b = find(b);
+
+        if (parent_a != parent_b) parents[parent_b] = parent_a;
+    }
+
+    static int find(int node) {
+        if (parents[node] == node) return node;
+        return parents[node] = find(parents[node]);
+    }
+}


### PR DESCRIPTION
유니온 파인드

- 유니온(Union) → 루트 노드 갱신 (집합 합치기)
두 개의 노드가 속한 집합을 하나로 합침
즉, 한 집합의 루트 노드를 다른 집합의 루트 노드에 연결
보통 더 작은 쪽을 부모로 설정하는 로직 (Union by Rank/Size) 을 추가하면 성능이 더 좋아짐

- 파인드(Find) → 경로 압축 (Path Compression)
주어진 노드가 속한 집합의 대표(루트) 노드를 찾음
이 과정에서 찾는 도중의 모든 노드를 루트에 직접 연결하여 트리의 높이를 낮춤 (경로 압축)
결과적으로 이후 find() 호출이 거의 O(1)에 가까운 속도로 실행됨

<img width="1299" alt="image" src="https://github.com/user-attachments/assets/62092cc5-dbc5-491a-8e7f-3c688f92f502" />
